### PR TITLE
Add COMPOSITE to Keywords

### DIFF
--- a/Notepad++/mapfile.xml
+++ b/Notepad++/mapfile.xml
@@ -17,6 +17,7 @@
 		<KeyWord name="CLASS" />
 		<KeyWord name="CLASSITEM" />
 		<KeyWord name="COLOR" />
+		<KeyWord name="COMPOSITE" />
 		<KeyWord name="CONFIG" />
 		<KeyWord name="CONNECTION" />
 		<KeyWord name="CONNECTIONTYPE" />


### PR DESCRIPTION
Since Mapserver 7 adds new class COMPOSITE

http://mapserver.org/fr/mapfile/composite.html#composite

Since TRANSPARENCY and OPACITY are now obsolete : http://mapserver.org/fr/mapfile/layer.html